### PR TITLE
PRC network endpoint configuration through settings

### DIFF
--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -137,14 +137,20 @@ export async function activate(context: vscode.ExtensionContext) {
     }),
     // Set Network
     commands.registerCommand('ethcode.network.set', () => {
-      const quickPick = window.createQuickPick<INetworkQP>();
-      const options: Array<INetworkQP> = [
+      const defaultOptions: Array<INetworkQP> = [
         { label: 'Main', networkId: 1 },
         { label: 'Ropsten', networkId: 3 },
         { label: 'Rinkeby', networkId: 4 },
         { label: 'Goerli', networkId: 5 },
       ];
-      quickPick.items = options.map((network) => ({ label: network.label, networkId: network.networkId }));
+      const networks: Array<INetworkQP> = workspace.getConfiguration('ethcode').get('networks') || defaultOptions;
+      const options: Array<INetworkQP> = networks.map((nw: any) => ({
+        networkId: nw.networkId,
+        label: nw.label,
+        ...nw,
+      }));
+      const quickPick = window.createQuickPick<INetworkQP>();
+      quickPick.items = options;
       quickPick.placeholder = 'Select network';
       quickPick.onDidChangeActive((selection: Array<INetworkQP>) => {
         quickPick.value = selection[0].label;

--- a/ext-src/types/types.ts
+++ b/ext-src/types/types.ts
@@ -42,6 +42,12 @@ export interface ICompilationResult {
 
 export interface INetworkQP extends QuickPickItem {
   networkId: number;
+  networkName?: string;
+  rpcUrl?: string;
+  currencySymbol?: string;
+  blockExplorer?: string;
+  port?: string;
+  websocketUrl?: string;
 }
 
 export interface IAccountQP extends QuickPickItem {


### PR DESCRIPTION
Taking only networkId(chainId) as mandatory and other properties are optional. 
if settings.json does not exists in .vscode directory the default values from code will be used.

Steps to test:
1. run extension
2. cmd + p > preferences: open workspace settings (JSON)
3. add  "ethcode.networks" key and array of objects with network details is value
```
{
  "ethcode.networks": [
    { 
      "networkId": number,
      "label": network name or any name for dev to understand,
      "networkName": string,
      "rpcUrl": string,
      "currencySymbol": string,
      "blockExplorer": string,
      "port": string,
      "websocketUrl": string, 
    },
  ]
}